### PR TITLE
Run composer validate during CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+name: Composer validate
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    # Run on all PRs
+
+env:
+  CI: "true"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+
+      - name: Run validate
+        run: composer validate


### PR DESCRIPTION
Since this template is intended for published libraries, it's beneficial to validate `composer.json` as part of CI to ensure everything ends up in a publishable state.