### PR TITLE
Move back to explicit branch name in workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - $default-branch
+      - main
   pull_request:
     # Run on all PRs
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,7 +3,7 @@ name: Static analysis
 on:
   push:
     branches:
-      - $default-branch
+      - main
   pull_request:
     # Run on all PRs
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - $default-branch
+      - main
   pull_request:
     # Run on all PRs
 


### PR DESCRIPTION
$default-branch macro doesn't work in actual workflows