### PR TITLE
Update default PHP version ranges based on current support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,10 @@ jobs:
           - 'high'
           - 'low'
         php:
-          - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
+          - '8.2'
 
     steps:
       - name: Check out code

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
         "mheap/phpunit-github-actions-printer": "^1.5",


### PR DESCRIPTION
PHP 7.3 support was dropped when 8.1 was relased. Also default to testing on 8.2.