### PR TITLE
Block older versions of php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
         "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
+    "conflict": {
+        "nikic/php-parser": "<v4.12"
+    },
     "scripts": {
         "test": [
             "@phpunit",


### PR DESCRIPTION
This fixes issues during code coverage analysis along the lines of `PHP Fatal error:  Uncaught PHPUnit\Framework\Error\Warning: Undefined array key 403 in .../vendor/nikic/php-parser/lib/PhpParser/Lexer.php:323`